### PR TITLE
Add Java code generation support to Natty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+- Build library: `bazel build :<target> --action_env=LLM_API_KEY=<your_gemini_api_key>`
+- Run binary: `bazel run :<target> --action_env=LLM_API_KEY=<your_gemini_api_key>`
+- Generate requirements.txt: `bazel run //:generate_requirements_txt`
+- Create virtual environment: `bazel run //:create_venv`
+- Sync virtual environment: `bazel run //:sync_venv`
+
+## Code Style Guidelines
+
+- Use Python 3.10+ syntax (e.g., `list[str]` instead of `List[str]`)
+- Use union syntax in Python types (e.g., `str | None` instead of `Optional[str]`)
+- Add proper type hints to all functions and variables
+- Include docstrings for all functions and classes
+- Add appropriate error handling
+- Follow PEP 8 style guidelines
+- Ensure code is well-structured and follows best practices
+- When implementing Natty components, focus on clear, concise behavior descriptions
+- For markdown descriptions, be specific about the expected functionality
+- Follow existing patterns when working with Bazel rules

--- a/examples/pretty_printer_cli/BUILD
+++ b/examples/pretty_printer_cli/BUILD
@@ -1,4 +1,10 @@
-load("//rules_natty:defs.bzl", "natty_binary", "natty_library")
+load(
+    "//rules_natty:defs.bzl", 
+    "natty_binary", 
+    "natty_library",
+    "natty_java_binary", 
+    "natty_java_library"
+)
 
 # Test out this Natty program using the following command:
 #
@@ -15,4 +21,15 @@ natty_library(
     name = "pretty_print",
     src = "pretty_print.md",
     visibility = ["//visibility:public"]
+)
+
+# Exact same as the above but codegen'ing Java.
+natty_java_binary( name = "java_cli_printer",
+    src = "cli_printer.md",
+    deps = [":java_pretty_print"],
+)
+
+natty_java_library(
+    name = "java_pretty_print",
+    src = "pretty_print.md",
 )

--- a/examples/pretty_printer_cli/pretty_print.md
+++ b/examples/pretty_printer_cli/pretty_print.md
@@ -1,4 +1,4 @@
-A simple python function that prints the given string inside a box.
+A simple function that prints the given string inside a box.
 
 Provide a secondary implementation that allows the pretty printed value to be returned
 as a pretty formatted string instead of immediately printing it to stdout.


### PR DESCRIPTION
- Update nattyc/main.py to support Java code generation:
  - Add Language class to specify Python or Java
  - Implement language-specific system prompts
  - Add Java-specific validation
  - Ensure Java code includes proper package and class naming

- Update rules_natty/defs.bzl with Java rules:
  - Add natty_java_library and natty_java_binary macros
  - Update NattyInfo provider to handle different languages
  - Add helper for Java package naming
  - Add validation to ensure file/class naming conventions

- Add CLAUDE.md with build instructions and code style guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)